### PR TITLE
feat(preview): enrich frontmatter properties block

### DIFF
--- a/src/client/application/markdown-frontmatter.js
+++ b/src/client/application/markdown-frontmatter.js
@@ -1,8 +1,28 @@
 import yaml from 'js-yaml';
 
-import { escapeHtml } from '../domain/vault-utils.js';
+import { escapeHtml, resolveWikiTarget } from '../domain/vault-utils.js';
 
 export { extractYamlFrontmatter } from '../../domain/yaml-frontmatter.js';
+
+const TAG_KEYS = new Set(['tag', 'tags']);
+const ALIAS_KEYS = new Set(['alias', 'aliases']);
+const URL_PATTERN = /^https?:\/\/\S+$/i;
+const WIKI_LINK_PATTERN = /^\[\[([^\]|]+)(?:\|([^\]]+))?\]\]$/;
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const ICON_ATTRS = 'width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"';
+
+const TYPE_ICONS = {
+  bool: `<svg ${ICON_ATTRS}><polyline points="20 6 9 17 4 12"/></svg>`,
+  date: `<svg ${ICON_ATTRS}><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>`,
+  empty: `<svg ${ICON_ATTRS}><line x1="5" y1="12" x2="19" y2="12"/></svg>`,
+  link: `<svg ${ICON_ATTRS}><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>`,
+  list: `<svg ${ICON_ATTRS}><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>`,
+  number: `<svg ${ICON_ATTRS}><line x1="4" y1="9" x2="20" y2="9"/><line x1="4" y1="15" x2="20" y2="15"/><line x1="10" y1="3" x2="8" y2="21"/><line x1="16" y1="3" x2="14" y2="21"/></svg>`,
+  object: `<svg ${ICON_ATTRS}><path d="M8 3H6a2 2 0 0 0-2 2v4a2 2 0 0 1-2 2 2 2 0 0 1 2 2v4a2 2 0 0 0 2 2h2"/><path d="M16 3h2a2 2 0 0 1 2 2v4a2 2 0 0 0 2 2 2 2 0 0 0-2 2v4a2 2 0 0 1-2 2h-2"/></svg>`,
+  tags: `<svg ${ICON_ATTRS}><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg>`,
+  text: `<svg ${ICON_ATTRS}><polyline points="4 7 4 4 20 4 20 7"/><line x1="9" y1="20" x2="15" y2="20"/><line x1="12" y1="4" x2="12" y2="20"/></svg>`,
+  wikilink: `<svg ${ICON_ATTRS}><path d="M9 6H5a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h4"/><path d="M15 6h4a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-4"/></svg>`,
+};
 
 function isPlainObject(value) {
   return Object.prototype.toString.call(value) === '[object Object]';
@@ -18,15 +38,212 @@ function isScalarValue(value) {
   );
 }
 
-function formatScalarValue(value) {
+function isDateOnly(date) {
+  return (
+    date.getUTCHours() === 0
+    && date.getUTCMinutes() === 0
+    && date.getUTCSeconds() === 0
+    && date.getUTCMilliseconds() === 0
+  );
+}
+
+function pad2(value) {
+  return String(value).padStart(2, '0');
+}
+
+function formatDate(date) {
+  const year = date.getUTCFullYear();
+  const month = pad2(date.getUTCMonth() + 1);
+  const day = pad2(date.getUTCDate());
+
+  if (isDateOnly(date)) {
+    return `${year}-${month}-${day}`;
+  }
+
+  const hours = pad2(date.getUTCHours());
+  const minutes = pad2(date.getUTCMinutes());
+  return `${year}-${month}-${day} ${hours}:${minutes}`;
+}
+
+function detectScalarType(key, value) {
+  if (value == null || value === '') {
+    return 'empty';
+  }
+
   if (value instanceof Date) {
-    return value.toISOString();
+    return 'date';
   }
 
-  if (value == null) {
-    return 'null';
+  if (typeof value === 'boolean') {
+    return 'bool';
   }
 
+  if (typeof value === 'number') {
+    return 'number';
+  }
+
+  if (typeof value === 'string') {
+    if (DATE_ONLY_PATTERN.test(value.trim())) {
+      return 'date';
+    }
+    if (URL_PATTERN.test(value.trim())) {
+      return 'link';
+    }
+    if (WIKI_LINK_PATTERN.test(value.trim())) {
+      return 'wikilink';
+    }
+    if (key && TAG_KEYS.has(key.toLowerCase())) {
+      return 'tags';
+    }
+    return 'text';
+  }
+
+  return 'text';
+}
+
+function renderWikiLinkValue(rawText, ctx) {
+  const match = WIKI_LINK_PATTERN.exec(rawText.trim());
+  if (!match) {
+    return null;
+  }
+
+  const target = match[1].trim();
+  const display = (match[2] ?? match[1]).trim();
+  const fileList = ctx?.fileList ?? [];
+  const resolved = resolveWikiTarget(target, fileList);
+  const classes = resolved ? 'wiki-link' : 'wiki-link wiki-link-new';
+  const title = resolved
+    ? display
+    : ctx?.wikiLinkAutoCreate
+      ? `Create "${target}"`
+      : `Missing "${target}"`;
+
+  return `<a class="${classes}" href="#" data-wiki-target="${escapeHtml(target)}" title="${escapeHtml(title)}">${escapeHtml(display)}</a>`;
+}
+
+function renderUrlValue(rawText) {
+  const href = rawText.trim();
+  return `<a class="frontmatter-value-link" href="${escapeHtml(href)}" target="_blank" rel="noreferrer noopener">${escapeHtml(href)}</a>`;
+}
+
+function renderEmptyValue() {
+  return '<span class="frontmatter-value-empty">Empty</span>';
+}
+
+function renderScalarMarkup(key, value, ctx) {
+  const type = detectScalarType(key, value);
+
+  if (type === 'empty') {
+    return { html: renderEmptyValue(), type };
+  }
+
+  if (type === 'date') {
+    const formatted = value instanceof Date ? formatDate(value) : String(value).trim();
+    const datetime = value instanceof Date ? value.toISOString() : formatted;
+    return {
+      html: `<time class="frontmatter-value-date" datetime="${escapeHtml(datetime)}">${escapeHtml(formatted)}</time>`,
+      type,
+    };
+  }
+
+  if (type === 'bool') {
+    const truthy = value === true;
+    const label = truthy ? '✓ true' : '✗ false';
+    return {
+      html: `<span class="frontmatter-value-bool" data-value="${truthy}">${label}</span>`,
+      type,
+    };
+  }
+
+  if (type === 'number') {
+    return {
+      html: `<span class="frontmatter-value-number">${escapeHtml(String(value))}</span>`,
+      type,
+    };
+  }
+
+  if (type === 'link') {
+    return { html: renderUrlValue(String(value)), type };
+  }
+
+  if (type === 'wikilink') {
+    const wikiHtml = renderWikiLinkValue(String(value), ctx);
+    if (wikiHtml) {
+      return { html: wikiHtml, type };
+    }
+  }
+
+  if (type === 'tags') {
+    return {
+      html: `<span class="frontmatter-value-pill frontmatter-value-tag">#${escapeHtml(String(value))}</span>`,
+      type,
+    };
+  }
+
+  return {
+    html: `<span class="frontmatter-value-text">${escapeHtml(String(value))}</span>`,
+    type: 'text',
+  };
+}
+
+function renderArrayMarkup(key, items, ctx) {
+  const lowerKey = (key ?? '').toLowerCase();
+  const isTagKey = TAG_KEYS.has(lowerKey);
+  const isAliasKey = ALIAS_KEYS.has(lowerKey);
+  const allScalar = items.every((item) => isScalarValue(item));
+
+  if (!allScalar) {
+    return {
+      html: `<pre class="frontmatter-value-code"><code>${escapeHtml(serializeComplexValue(items))}</code></pre>`,
+      type: 'object',
+    };
+  }
+
+  if (items.length === 0) {
+    return {
+      html: `<div class="frontmatter-value-list">${renderEmptyValue()}</div>`,
+      type: isTagKey ? 'tags' : isAliasKey ? 'aliases' : 'list',
+    };
+  }
+
+  const pills = items.map((item) => {
+    if (item == null || item === '') {
+      return `<span class="frontmatter-value-pill frontmatter-value-pill-empty">Empty</span>`;
+    }
+
+    if (isTagKey) {
+      return `<span class="frontmatter-value-pill frontmatter-value-tag">#${escapeHtml(formatPillScalar(item))}</span>`;
+    }
+
+    if (isAliasKey) {
+      return `<span class="frontmatter-value-pill frontmatter-value-alias">${escapeHtml(formatPillScalar(item))}</span>`;
+    }
+
+    if (typeof item === 'string') {
+      const wikiHtml = WIKI_LINK_PATTERN.test(item.trim())
+        ? renderWikiLinkValue(item, ctx)
+        : null;
+      if (wikiHtml) {
+        return wikiHtml;
+      }
+      if (URL_PATTERN.test(item.trim())) {
+        return renderUrlValue(item);
+      }
+    }
+
+    return `<span class="frontmatter-value-pill">${escapeHtml(formatPillScalar(item))}</span>`;
+  }).join('');
+
+  return {
+    html: `<div class="frontmatter-value-list">${pills}</div>`,
+    type: isTagKey ? 'tags' : isAliasKey ? 'aliases' : 'list',
+  };
+}
+
+function formatPillScalar(value) {
+  if (value instanceof Date) {
+    return formatDate(value);
+  }
   return String(value);
 }
 
@@ -37,18 +254,19 @@ function serializeComplexValue(value) {
   }).trim();
 }
 
-function createFrontmatterValueMarkup(value) {
-  if (isScalarValue(value)) {
-    return `<span class="frontmatter-value-text">${escapeHtml(formatScalarValue(value))}</span>`;
+function createValueMarkup(key, value, ctx) {
+  if (Array.isArray(value)) {
+    return renderArrayMarkup(key, value, ctx);
   }
 
-  if (Array.isArray(value) && value.every((item) => isScalarValue(item))) {
-    return `<div class="frontmatter-value-list">${value
-      .map((item) => `<span class="frontmatter-value-pill">${escapeHtml(formatScalarValue(item))}</span>`)
-      .join('')}</div>`;
+  if (isPlainObject(value)) {
+    return {
+      html: `<pre class="frontmatter-value-code"><code>${escapeHtml(serializeComplexValue(value))}</code></pre>`,
+      type: 'object',
+    };
   }
 
-  return `<pre class="frontmatter-value-code"><code>${escapeHtml(serializeComplexValue(value))}</code></pre>`;
+  return renderScalarMarkup(key, value, ctx);
 }
 
 function createFrontmatterEntries(data) {
@@ -67,14 +285,22 @@ function createHiddenSummary(entries) {
   return `${entries.length} propert${entries.length === 1 ? 'y' : 'ies'} hidden`;
 }
 
+function createIconMarkup(type) {
+  const svg = TYPE_ICONS[type] ?? TYPE_ICONS.text;
+  return `<span class="frontmatter-icon">${svg}</span>`;
+}
+
 export function renderFrontmatterBlock(frontmatter, {
   collapsed = false,
+  fileList = [],
   interactive = false,
+  wikiLinkAutoCreate = true,
 } = {}) {
   if (!frontmatter) {
     return '';
   }
 
+  const ctx = { fileList, wikiLinkAutoCreate };
   const entries = createFrontmatterEntries(frontmatter.data);
   const collapsedState = interactive && collapsed;
   const sourceAttributes = ` data-source-line="${frontmatter.startLine}" data-source-line-end="${frontmatter.endLine}"${interactive ? ` data-collapsed="${collapsedState ? 'true' : 'false'}"` : ''}`;
@@ -82,9 +308,12 @@ export function renderFrontmatterBlock(frontmatter, {
   const emptyState = entries.length === 0
     ? '<div class="frontmatter-empty">No properties</div>'
     : '';
-  const items = entries.map(([key, value]) => (
-    `<div class="frontmatter-property"><dt class="frontmatter-key">${escapeHtml(key)}</dt><dd class="frontmatter-value">${createFrontmatterValueMarkup(value)}</dd></div>`
-  )).join('');
+  const items = entries.map(([key, value]) => {
+    const { html, type } = createValueMarkup(key, value, ctx);
+    return (
+      `<div class="frontmatter-property" data-type="${escapeHtml(type)}"><dt class="frontmatter-key">${createIconMarkup(type)}<span class="frontmatter-key-text">${escapeHtml(key)}</span></dt><dd class="frontmatter-value">${html}</dd></div>`
+    );
+  }).join('');
   const header = interactive
     ? `<div class="frontmatter-header"><div class="frontmatter-label">Properties</div><button type="button" class="frontmatter-toggle" aria-controls="${bodyId}" aria-expanded="${collapsedState ? 'false' : 'true'}">${collapsedState ? 'Show' : 'Hide'}</button></div>`
     : '<div class="frontmatter-label">Properties</div>';

--- a/src/client/application/preview-render-compiler.js
+++ b/src/client/application/preview-render-compiler.js
@@ -658,7 +658,9 @@ export function compilePreviewDocument({
   const renderedMarkdown = frontmatter ? frontmatter.bodyMarkdown : normalizedMarkdown;
   const frontmatterHtml = renderFrontmatterBlock(frontmatter, {
     collapsed: frontmatterCollapsed,
+    fileList,
     interactive: frontmatterInteractive,
+    wikiLinkAutoCreate,
   });
 
   return {

--- a/src/client/application/preview-renderer.js
+++ b/src/client/application/preview-renderer.js
@@ -45,7 +45,7 @@ export class PreviewRenderer {
     this.currentStats = null;
     this.isLargeDocument = false;
     this.hydrationPaused = false;
-    this.frontmatterCollapsed = false;
+    this.frontmatterCollapsed = true;
 
     this.handlePreviewClick = (event) => {
       const frontmatterToggle = event.target.closest('.frontmatter-toggle');
@@ -160,7 +160,7 @@ export class PreviewRenderer {
     this.readyRenderVersion = 0;
     this.currentStats = null;
     this.isLargeDocument = false;
-    this.frontmatterCollapsed = false;
+    this.frontmatterCollapsed = true;
     if (this.renderExecutor.hasPendingJob()) {
       this.resetWorker('Document changed');
     }

--- a/src/client/styles/features/preview-markdown.css
+++ b/src/client/styles/features/preview-markdown.css
@@ -109,7 +109,6 @@
 }
 
 .preview-content .frontmatter-block {
-  max-width: 72ch;
   margin: 0 0 var(--space-5);
   padding: var(--space-4);
   border: 1px solid var(--color-border);
@@ -168,27 +167,71 @@
 
 .preview-content .frontmatter-properties {
   display: grid;
-  gap: var(--space-3);
+  gap: var(--space-2);
   margin: 0;
 }
 
 .preview-content .frontmatter-property {
   display: grid;
-  grid-template-columns: minmax(0, 160px) minmax(0, 1fr);
-  gap: var(--space-3);
+  grid-template-columns: minmax(120px, max-content) minmax(0, 1fr);
+  gap: var(--space-4);
   align-items: start;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-md);
+  transition: background var(--transition-interactive);
+}
+
+.preview-content .frontmatter-property:hover {
+  background: color-mix(in oklab, var(--color-surface-offset) 50%, transparent);
 }
 
 .preview-content .frontmatter-key {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
   margin: 0;
+  min-height: 26px;
   color: var(--color-text-muted);
   font-size: var(--text-ui-sm);
-  font-weight: 600;
+  font-weight: 500;
+}
+
+.preview-content .frontmatter-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  color: var(--color-text-faint);
+}
+
+.preview-content .frontmatter-icon > svg {
+  width: 14px;
+  height: 14px;
+}
+
+.preview-content .frontmatter-property[data-type="tags"] .frontmatter-icon,
+.preview-content .frontmatter-property[data-type="link"] .frontmatter-icon,
+.preview-content .frontmatter-property[data-type="wikilink"] .frontmatter-icon {
+  color: color-mix(in oklab, var(--color-primary) 70%, var(--color-text-muted));
+}
+
+.preview-content .frontmatter-key-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .preview-content .frontmatter-value {
   min-width: 0;
   margin: 0;
+  min-height: 26px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  color: var(--color-text);
 }
 
 .preview-content .frontmatter-value-text {
@@ -197,16 +240,73 @@
   overflow-wrap: anywhere;
 }
 
+.preview-content .frontmatter-value-number {
+  display: inline-block;
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum";
+}
+
+.preview-content .frontmatter-value-date {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklab, var(--color-surface-offset) 60%, transparent);
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum";
+}
+
+.preview-content .frontmatter-value-bool {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 24px;
+  padding: 0 var(--space-2);
+  border-radius: 999px;
+  font-size: var(--text-ui-sm);
+  font-weight: 500;
+}
+
+.preview-content .frontmatter-value-bool[data-value="true"] {
+  background: color-mix(in oklab, var(--color-success, var(--color-primary)) 14%, transparent);
+  color: var(--color-success, var(--color-primary));
+}
+
+.preview-content .frontmatter-value-bool[data-value="false"] {
+  background: color-mix(in oklab, var(--color-text-muted) 14%, transparent);
+  color: var(--color-text-muted);
+}
+
+.preview-content .frontmatter-value-link {
+  color: var(--color-primary);
+  text-decoration: none;
+  border-bottom: 1px solid oklch(from var(--color-primary) l c h / 0.3);
+  overflow-wrap: anywhere;
+}
+
+.preview-content .frontmatter-value-link:hover {
+  border-bottom-color: var(--color-primary);
+}
+
+.preview-content .frontmatter-value-empty {
+  color: var(--color-text-faint);
+  font-style: italic;
+  font-size: var(--text-ui-sm);
+}
+
 .preview-content .frontmatter-value-list {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-2);
+  width: 100%;
 }
 
 .preview-content .frontmatter-value-pill {
   display: inline-flex;
   align-items: center;
-  min-height: 28px;
+  min-height: 24px;
   padding: 0 var(--space-3);
   border: 1px solid var(--color-border);
   border-radius: 999px;
@@ -215,8 +315,25 @@
   font-size: var(--text-ui-sm);
 }
 
+.preview-content .frontmatter-value-tag {
+  border-color: color-mix(in oklab, var(--color-primary) 32%, var(--color-border));
+  background: color-mix(in oklab, var(--color-primary) 8%, var(--color-surface));
+  color: var(--color-primary);
+  font-weight: 500;
+}
+
+.preview-content .frontmatter-value-alias {
+  font-style: italic;
+}
+
+.preview-content .frontmatter-value-pill-empty {
+  color: var(--color-text-faint);
+  font-style: italic;
+}
+
 .preview-content .frontmatter-value-code {
   margin: 0;
+  width: 100%;
   border-radius: var(--radius-md);
 }
 
@@ -1118,5 +1235,9 @@
   .preview-content .frontmatter-property {
     grid-template-columns: 1fr;
     gap: var(--space-1);
+  }
+
+  .preview-content .frontmatter-value {
+    min-height: 0;
   }
 }

--- a/tests/node/preview-render-compiler.test.js
+++ b/tests/node/preview-render-compiler.test.js
@@ -224,11 +224,13 @@ test('compilePreviewDocument renders YAML frontmatter as a metadata block and pr
 
   assert.match(html, /<section class="frontmatter-block" data-source-line="1" data-source-line-end="6">/);
   assert.match(html, /<div class="frontmatter-label">Properties<\/div>/);
-  assert.match(html, /<dt class="frontmatter-key">title<\/dt>/);
+  assert.match(html, /<div class="frontmatter-property" data-type="text">/);
+  assert.match(html, /<span class="frontmatter-key-text">title<\/span>/);
   assert.match(html, /<span class="frontmatter-value-text">Demo note<\/span>/);
-  assert.match(html, /<dt class="frontmatter-key">tags<\/dt>/);
-  assert.match(html, /<span class="frontmatter-value-pill">alpha<\/span>/);
-  assert.match(html, /<span class="frontmatter-value-pill">beta<\/span>/);
+  assert.match(html, /<div class="frontmatter-property" data-type="tags">/);
+  assert.match(html, /<span class="frontmatter-key-text">tags<\/span>/);
+  assert.match(html, /<span class="frontmatter-value-pill frontmatter-value-tag">#alpha<\/span>/);
+  assert.match(html, /<span class="frontmatter-value-pill frontmatter-value-tag">#beta<\/span>/);
   assert.doesNotMatch(html, /<hr>\s*<p[^>]*>title: Demo note/);
   assert.match(html, /<h1[^>]*data-source-line="8"[^>]*data-source-line-end="8"[^>]*id="heading"[^>]*>Heading<\/h1>/);
   assert.match(html, /<p data-source-line="10" data-source-line-end="10">Body copy<\/p>/);
@@ -251,9 +253,11 @@ test('compilePreviewDocument renders complex and empty YAML frontmatter values',
   const { html } = compilePreviewDocument({ markdownText: markdown });
 
   assert.match(html, /<section class="frontmatter-block" data-source-line="1" data-source-line-end="8">/);
-  assert.match(html, /<dt class="frontmatter-key">aliases<\/dt>/);
-  assert.match(html, /<div class="frontmatter-value-list"><\/div>/);
-  assert.match(html, /<dt class="frontmatter-key">config<\/dt>/);
+  assert.match(html, /<div class="frontmatter-property" data-type="aliases">/);
+  assert.match(html, /<span class="frontmatter-key-text">aliases<\/span>/);
+  assert.match(html, /<div class="frontmatter-value-list"><span class="frontmatter-value-empty">Empty<\/span><\/div>/);
+  assert.match(html, /<div class="frontmatter-property" data-type="object">/);
+  assert.match(html, /<span class="frontmatter-key-text">config<\/span>/);
   assert.match(html, /<pre class="frontmatter-value-code"><code>theme: ocean/);
   assert.match(html, /widgets:\n {2}- chart\n {2}- table/);
 });
@@ -294,6 +298,99 @@ test('compilePreviewDocument renders interactive frontmatter controls for previe
   assert.match(html, /<button type="button" class="frontmatter-toggle" aria-controls="frontmatter-body-1-5" aria-expanded="false">Show<\/button>/);
   assert.match(html, /<div class="frontmatter-summary">2 properties hidden<\/div>/);
   assert.match(html, /<div class="frontmatter-content" id="frontmatter-body-1-5" hidden>/);
+});
+
+test('compilePreviewDocument formats date-only frontmatter values without time component', () => {
+  const markdown = [
+    '---',
+    'created: 2026-05-06',
+    'modified: 2026-01-15T10:30:00Z',
+    '---',
+    '',
+    '# Heading',
+  ].join('\n');
+
+  const { html } = compilePreviewDocument({ markdownText: markdown });
+
+  assert.match(html, /<div class="frontmatter-property" data-type="date">/);
+  assert.match(html, /<time class="frontmatter-value-date" datetime="2026-05-06T00:00:00\.000Z">2026-05-06<\/time>/);
+  assert.match(html, /<time class="frontmatter-value-date"[^>]*>2026-01-15 10:30<\/time>/);
+});
+
+test('compilePreviewDocument renders booleans, numbers, and empty placeholders with type metadata', () => {
+  const markdown = [
+    '---',
+    'published: true',
+    'draft: false',
+    'priority: 42',
+    'note:',
+    '---',
+    '',
+    '# Heading',
+  ].join('\n');
+
+  const { html } = compilePreviewDocument({ markdownText: markdown });
+
+  assert.match(html, /<div class="frontmatter-property" data-type="bool">[\s\S]*?<span class="frontmatter-value-bool" data-value="true">✓ true<\/span>/);
+  assert.match(html, /<span class="frontmatter-value-bool" data-value="false">✗ false<\/span>/);
+  assert.match(html, /<div class="frontmatter-property" data-type="number">[\s\S]*?<span class="frontmatter-value-number">42<\/span>/);
+  assert.match(html, /<div class="frontmatter-property" data-type="empty">[\s\S]*?<span class="frontmatter-value-empty">Empty<\/span>/);
+});
+
+test('compilePreviewDocument turns URL frontmatter values into external links', () => {
+  const markdown = [
+    '---',
+    'homepage: https://example.com/path',
+    '---',
+    '',
+    '# Heading',
+  ].join('\n');
+
+  const { html } = compilePreviewDocument({ markdownText: markdown });
+
+  assert.match(html, /<div class="frontmatter-property" data-type="link">/);
+  assert.match(html, /<a class="frontmatter-value-link" href="https:\/\/example\.com\/path" target="_blank" rel="noreferrer noopener">https:\/\/example\.com\/path<\/a>/);
+});
+
+test('compilePreviewDocument resolves wiki-link strings inside frontmatter', () => {
+  const markdown = [
+    '---',
+    'related: "[[README]]"',
+    'broken: "[[missing-note|See it]]"',
+    '---',
+    '',
+    '# Heading',
+  ].join('\n');
+
+  const { html } = compilePreviewDocument({
+    fileList: ['README.md'],
+    markdownText: markdown,
+  });
+
+  assert.match(html, /<div class="frontmatter-property" data-type="wikilink">/);
+  assert.match(html, /<a class="wiki-link" href="#" data-wiki-target="README" title="README">README<\/a>/);
+  assert.match(html, /<a class="wiki-link wiki-link-new" href="#" data-wiki-target="missing-note" title="Create &quot;missing-note&quot;">See it<\/a>/);
+});
+
+test('compilePreviewDocument prefixes tag pills with hash and styles aliases distinctly', () => {
+  const markdown = [
+    '---',
+    'tags:',
+    '  - alpha',
+    '  - beta',
+    'aliases:',
+    '  - "Alt name"',
+    '---',
+    '',
+    '# Heading',
+  ].join('\n');
+
+  const { html } = compilePreviewDocument({ markdownText: markdown });
+
+  assert.match(html, /<div class="frontmatter-property" data-type="tags">/);
+  assert.match(html, /<span class="frontmatter-value-pill frontmatter-value-tag">#alpha<\/span>/);
+  assert.match(html, /<div class="frontmatter-property" data-type="aliases">/);
+  assert.match(html, /<span class="frontmatter-value-pill frontmatter-value-alias">Alt name<\/span>/);
 });
 
 test('compilePreviewDocument normalizes ASCII arrows in preview text', () => {


### PR DESCRIPTION
## Summary

- Render the YAML frontmatter section as a type-aware Properties panel (Obsidian-like) instead of a flat key/value list.
- Detect per-value type — text, date, number, bool, link, wikilink, tags, aliases, list, object, empty — and emit a small SVG icon for each type.
- Format `Date` values as `YYYY-MM-DD` when the YAML literal is date-only, falling back to `YYYY-MM-DD HH:mm` for full timestamps.
- Render booleans as ✓/✗ pills, numbers with tabular numerals, URLs as external anchors, and bare `[[wiki-link]]` strings through the same resolver as body wiki-links (respects `wikiLinkAutoCreate`).
- Special-case `tags` (# prefix, accent pill) and `aliases` (italic pill); show an italic "Empty" placeholder for null/missing values.
- Replace the fixed `160px` key column with intrinsic sizing, drop the `72ch` max-width on the block, and collapse the panel by default in interactive preview so the body is the focus on open.

## Files

- `src/client/application/markdown-frontmatter.js` — full rewrite of the renderer with type detection, icons, and special-case keys.
- `src/client/application/preview-render-compiler.js` — thread `fileList` and `wikiLinkAutoCreate` into `renderFrontmatterBlock` so wiki-links inside frontmatter use the existing resolver.
- `src/client/application/preview-renderer.js` — default `frontmatterCollapsed` to `true` so the panel is hidden on document open.
- `src/client/styles/features/preview-markdown.css` — styles for icons, type-specific values (date/bool/number/link/empty), tag accent pill, alias italic pill, intrinsic key column.
- `tests/node/preview-render-compiler.test.js` — update existing assertions for the new HTML structure and add 5 new tests covering date formatting, booleans/numbers/empty, URL detection, wiki-link resolution inside frontmatter, and tags/aliases pills.

## Test plan

- [x] `node --test tests/node/preview-render-compiler.test.js` — 35 pass (5 new).
- [x] `node --test tests/node/style-system-guardrails.test.js` — CSS parses, no undefined vars.
- [x] `npm run test:unit` (fast) — 430 pass.
- [x] `npx eslint src/client/application/markdown-frontmatter.js` — clean.
- [x] `npm run build` — vite build succeeds.
- [ ] Visual smoke in browser against a vault with frontmatter (date, bool, tags, aliases, wiki-link, URL, empty fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)